### PR TITLE
Context suggestions

### DIFF
--- a/src/Lean/Meta/PPGoal.lean
+++ b/src/Lean/Meta/PPGoal.lean
@@ -131,7 +131,8 @@ private def getInitialHiddenInaccessible (propOnly : Bool) : MetaM FVarIdSet := 
 /-
 If pp.inaccessibleNames == false, then collect two sets of `FVarId`s : `hiddenInaccessible` and `hiddenInaccessibleProp`
 1- `hiddenInaccessible` contains `FVarId`s of free variables with inaccessible names that
-    a) are not propositions or are propositions containing "visible" names.
+    a) are not propositions or
+    b) are propositions containing "visible" names.
 2- `hiddenInaccessibleProp` contains `FVarId`s of free variables with inaccessible names that are propositions
    containing "visible" names.
 Both sets do not contain `FVarId`s that contain visible backward or forward dependencies.

--- a/src/Lean/Widget/Basic.lean
+++ b/src/Lean/Widget/Basic.lean
@@ -19,4 +19,9 @@ structure InfoWithCtx where
 
 deriving instance RpcEncoding with { withRef := true } for MessageData
 
+instance : ToJson FVarId := ⟨fun f => toJson f.name⟩
+instance : ToJson MVarId := ⟨fun f => toJson f.name⟩
+instance : FromJson FVarId := ⟨fun j => FVarId.mk <$> fromJson? j⟩
+instance : FromJson MVarId := ⟨fun j => MVarId.mk <$> fromJson? j⟩
+
 end Lean.Widget


### PR DESCRIPTION
This is used to uniquely identify InteractiveGoals and
InteractiveHypotheses. This makes it easier to do
contextual suggestions: eg the infoview can send a message
saying "the user clicked on subexpression 5 in hypothesis N in goal G"
where N and G are unique identifiers for a goal rather than pretty names
which may be non-unique or indices which may be difficult to compute
(eg in infoview there is a mode where hypotheses are reversed or filtered).

While adding these I also refactored the InteractiveGoal generating function.
I unwrapped a fold in to a for/in loop with mutating variables which is a
little easier to read.